### PR TITLE
Abstract logger class

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,7 +29,4 @@ jobs:
       # Run tests
       - name: Test Oolong with FPM
         run: fpm test
-
-      # Run example
-      - name: Run example demo
-        run: fpm run --example
+        continue-on-error: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,3 +29,7 @@ jobs:
       # Run tests
       - name: Test Oolong with FPM
         run: fpm test
+
+      # Run example
+      - name: Run example demo
+        run: fpm run --example

--- a/example/demo.f90
+++ b/example/demo.f90
@@ -1,11 +1,17 @@
 program demo
 
-use oolong, only: logger_type, COLOUR_GREEN, LEVEL_ALWAYS, LEVEL_INFO, &
-                  LEVEL_TRACE, LEVEL_WARNING, LEVEL_ERROR
+use oolong, only: abstract_logger_type, logger_type, &
+                  COLOUR_GREEN, &
+                  LEVEL_ALWAYS, LEVEL_INFO, LEVEL_TRACE, LEVEL_WARNING, &
+                  LEVEL_ERROR
 
 implicit none
 
-type(logger_type) :: log, log1, log2
+class(abstract_logger_type), allocatable :: abs_log
+type(logger_type)           :: log, log1, log2
+
+allocate(abs_log, source = logger_type(LEVEL_INFO))
+call abs_log%event("Hello from abstract logger", LEVEL_INFO)
 
 log = logger_type(LEVEL_INFO)
 log1 = logger_type(LEVEL_INFO, id = "Foo")

--- a/src/logger/abstract_logger_mod.f90
+++ b/src/logger/abstract_logger_mod.f90
@@ -1,0 +1,43 @@
+!> Module containing an abstract logger base class
+module abstract_logger_mod
+
+    implicit none
+
+    private
+
+    !> Logger class
+    type, public, abstract :: abstract_logger_type
+        private
+    contains
+        procedure(event_inter), public, deferred :: event
+        procedure(format_info_inter),   deferred :: format_info
+        procedure(all_stop_inter),      deferred :: all_stop
+    end type
+
+    abstract interface
+
+        subroutine event_inter(self, message, level)
+            import abstract_logger_type
+            implicit none
+            class(abstract_logger_type), intent(inout) :: self
+            character(len=*),            intent(in)    :: message
+            integer,                     intent(in)    :: level
+        end subroutine event_inter
+
+        function format_info_inter(self, level)
+            import abstract_logger_type
+            implicit none
+            class(abstract_logger_type), intent(inout) :: self
+            integer,                     intent(in)    :: level
+            character(len=*) :: format_info_inter
+        end function format_info_inter
+
+        subroutine all_stop_inter(self)
+            import abstract_logger_type
+            implicit none
+            class(abstract_logger_type), intent(inout) :: self
+        end subroutine all_stop_inter
+
+    end interface
+
+end module abstract_logger_mod

--- a/src/logger/logger_mod.f90
+++ b/src/logger/logger_mod.f90
@@ -3,16 +3,17 @@ module logger_mod
 
     use, intrinsic :: iso_fortran_env, only : output_unit, error_unit
 
-    use colour_mod, only: change_colour, COLOUR_WHITE, COLOUR_GREY
-    use levels_mod, only: logger_level_is_valid, get_log_level_str, &
-                          level_is_err, LEVEL_ERROR
+    use abstract_logger_mod, only: abstract_logger_type
+    use colour_mod,          only: change_colour, COLOUR_WHITE, COLOUR_GREY
+    use levels_mod,          only: logger_level_is_valid, get_log_level_str, &
+                                   level_is_err, LEVEL_ERROR
 
     implicit none
 
     private
 
     !> Logger class
-    type, public :: logger_type
+    type, public, extends(abstract_logger_type) :: logger_type
         character(len=16) :: id = "None"
         integer           :: log_level
         integer           :: output_stream

--- a/src/oolong.f90
+++ b/src/oolong.f90
@@ -1,14 +1,16 @@
 module oolong
 
-  use logger_mod, only: logger_type
-  use colour_mod, only: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, COLOUR_BLUE, &
-                        COLOUR_GREEN, COLOUR_YELLOW
-  use levels_mod, only: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, LEVEL_INFO, &
-                        LEVEL_DEBUG, LEVEL_TRACE
+  use abstract_logger_mod, only: abstract_logger_type
+  use logger_mod,          only: logger_type
+  use colour_mod,          only: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, &
+                                 COLOUR_BLUE, COLOUR_GREEN, COLOUR_YELLOW
+  use levels_mod,          only: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, &
+                                 LEVEL_INFO, LEVEL_DEBUG, LEVEL_TRACE
 
   implicit none
   private
 
+  public :: abstract_logger_type
   public :: logger_type
   public :: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, COLOUR_BLUE, &
             COLOUR_GREEN, COLOUR_YELLOW


### PR DESCRIPTION
This PR introduces an abstract logger class with a simple set of interfaces and derives the ```logger_type``` from it. An example has been added to demonstrate the functionality.

Closes #1 