### PR TITLE
Mpi logging

### DIFF
--- a/.spack/packages/oolong/package.py
+++ b/.spack/packages/oolong/package.py
@@ -22,7 +22,11 @@ class Oolong(Package):
     version("head", branch="main")
     version("0.1.0", sha256="278e5fed51c4bb64454b623f1c53b209b1a772eb6ad1172e18a4b60e59d606a7")
 
+    variant("mpi", default=False, description="Enable parallel logging")
+
     depends_on("fpm")
+    depends_on("mpi", when="+mpi")
+
 
     def setup_build_environment(self, env):
         # For some Cray machines all compilers are wrapped in 'ftn' - look for
@@ -34,6 +38,10 @@ class Oolong(Package):
                 env.set("FPM_FC", self.compiler.fc)
         else:
             env.set("FPM_FC", self.compiler.fc)
+
+        if self.spec.satisfies("+mpi"):
+            env.set("FPM_FFLAGS", f"-DMPI -L{self.spec['mpi'].prefix}/lib")
+            env.set("FPM_LDFLAGS", f"-L{self.spec['mpi'].prefix}/lib")
 
     def install(self, spec, prefix):
         subprocess.run(["fpm", "install", "--prefix", "."])

--- a/example/demo.f90
+++ b/example/demo.f90
@@ -59,7 +59,8 @@ subroutine mpi_log_demo()
     call mpi_log1%event("Hello from logger 1", LEVEL_INFO)
 
     mpi_log2 = mpi_logger_type( LEVEL_INFO, mpi_comm_world, comm_rank, &
-                                id="Log 2", colour=COLOUR_GREEN )
+                                id="Log 2", colour=COLOUR_GREEN,       &
+                                root_rank_only=.true. )
     call mpi_log2%event("Hello from logger 2", LEVEL_INFO)
 
     call mpi_log1%event("TEST ERROR", LEVEL_ERROR)

--- a/example/demo.f90
+++ b/example/demo.f90
@@ -7,27 +7,66 @@ use oolong, only: abstract_logger_type, logger_type, &
 
 implicit none
 
-class(abstract_logger_type), allocatable :: abs_log
-type(logger_type)           :: log, log1, log2
-
-allocate(abs_log, source = logger_type(LEVEL_INFO))
-call abs_log%event("Hello from abstract logger", LEVEL_INFO)
-
 #if defined(MPI)
-print*, "MPI"
+call mpi_log_demo()
 #endif
 
-log = logger_type(LEVEL_INFO)
-log1 = logger_type(LEVEL_INFO, id = "Foo")
-log2 = logger_type(LEVEL_TRACE, id = "Bar", colour=COLOUR_GREEN)
+call serial_log_demo()
 
-call log%event("Hello", LEVEL_INFO)
-call log1%event("Hello from logger 1", LEVEL_INFO)
-call log1%event("Testing trace level from logger 1", LEVEL_TRACE)
-call log2%event("Hello from logger 2", LEVEL_INFO)
-call log2%event("Testing trace level from logger 2", LEVEL_TRACE)
+contains
 
-call log%event("Test warning", LEVEL_WARNING)
-call log%event("Test error", LEVEL_ERROR)
+subroutine serial_log_demo()
+
+    implicit none
+
+    class(abstract_logger_type), allocatable :: abs_log
+    type(logger_type)           :: log, log1, log2
+
+    allocate(abs_log, source = logger_type(LEVEL_INFO))
+    call abs_log%event("Hello from abstract logger", LEVEL_INFO)
+
+    log = logger_type(LEVEL_INFO)
+    log1 = logger_type(LEVEL_INFO, id = "Foo")
+    log2 = logger_type(LEVEL_TRACE, id = "Bar", colour=COLOUR_GREEN)
+
+    call log%event("Hello", LEVEL_INFO)
+    call log1%event("Hello from logger 1", LEVEL_INFO)
+    call log1%event("Testing trace level from logger 1", LEVEL_TRACE)
+    call log2%event("Hello from logger 2", LEVEL_INFO)
+    call log2%event("Testing trace level from logger 2", LEVEL_TRACE)
+
+    call log%event("Test warning", LEVEL_WARNING)
+    call log%event("Test error", LEVEL_ERROR)
+
+end subroutine serial_log_demo
+
+
+#if defined(MPI)
+subroutine mpi_log_demo()
+    use oolong, only: mpi_logger_type
+    use mpi, only: mpi_init, mpi_finalize, mpi_comm_world, mpi_comm_size, &
+                   mpi_comm_rank
+
+    implicit none
+
+    type(mpi_logger_type) :: mpi_log1, mpi_log2
+    integer :: ierr, comm_size, comm_rank
+
+    call mpi_init(ierr)
+    call mpi_comm_rank(mpi_comm_world, comm_rank, ierr)
+
+    mpi_log1 = mpi_logger_type(LEVEL_INFO, mpi_comm_world, comm_rank)
+    call mpi_log1%event("Hello from logger 1", LEVEL_INFO)
+
+    mpi_log2 = mpi_logger_type( LEVEL_INFO, mpi_comm_world, comm_rank, &
+                                id="Log 2", colour=COLOUR_GREEN )
+    call mpi_log2%event("Hello from logger 2", LEVEL_INFO)
+
+    call mpi_log1%event("TEST ERROR", LEVEL_ERROR)
+
+    call mpi_finalize(ierr)
+
+end subroutine mpi_log_demo
+#endif
 
 end program demo

--- a/example/demo.f90
+++ b/example/demo.f90
@@ -13,6 +13,10 @@ type(logger_type)           :: log, log1, log2
 allocate(abs_log, source = logger_type(LEVEL_INFO))
 call abs_log%event("Hello from abstract logger", LEVEL_INFO)
 
+#if defined(MPI)
+print*, "MPI"
+#endif
+
 log = logger_type(LEVEL_INFO)
 log1 = logger_type(LEVEL_INFO, id = "Foo")
 log2 = logger_type(LEVEL_TRACE, id = "Bar", colour=COLOUR_GREEN)

--- a/fpm.toml
+++ b/fpm.toml
@@ -18,5 +18,8 @@ implicit-typing = false
 implicit-external = false
 source-form = "free"
 
+[preprocess]
+[preprocess.cpp]
+
 [dependencies]
 test-drive = {git = "https://github.com/fortran-lang/test-drive"}

--- a/fpm.toml
+++ b/fpm.toml
@@ -10,6 +10,8 @@ auto-tests = true
 auto-examples = true
 module-naming = false
 external-modules = "mpi"
+# Needs to be activated for MPI build
+#link = ["mpi", "mpi_mpifh"]
 
 [install]
 library = true

--- a/fpm.toml
+++ b/fpm.toml
@@ -9,6 +9,7 @@ auto-executables = true
 auto-tests = true
 auto-examples = true
 module-naming = false
+external-modules = "mpi"
 
 [install]
 library = true
@@ -20,6 +21,8 @@ source-form = "free"
 
 [preprocess]
 [preprocess.cpp]
+suffixes = ["F90"]
+# Activate MPI macro to enable MPI logging support (requires installed MPI)
 
 [dependencies]
 test-drive = {git = "https://github.com/fortran-lang/test-drive"}

--- a/src/logger/mpi_logger_mod.F90
+++ b/src/logger/mpi_logger_mod.F90
@@ -1,7 +1,9 @@
 !> Module containing an flexible logger class
 module mpi_logger_mod
+#if defined(MPI)
 
     use, intrinsic :: iso_fortran_env, only : output_unit, error_unit
+    use mpi, only : mpi_abort, MPI_COMM_WORLD
 
     use abstract_logger_mod, only: abstract_logger_type
     use colour_mod,          only: change_colour, COLOUR_WHITE, COLOUR_GREY
@@ -156,4 +158,5 @@ contains
 
     end subroutine all_stop
 
+#endif
 end module mpi_logger_mod

--- a/src/logger/mpi_logger_mod.F90
+++ b/src/logger/mpi_logger_mod.F90
@@ -38,13 +38,15 @@ module mpi_logger_mod
 contains
 
     !> Constructor for the logger object
-    function mpi_logger_constructor(level, id, colour, stop_level, mpi_comm) result(self)
+    function mpi_logger_constructor( level, mpi_comm, mpi_rank, id, colour, &
+                                     stop_level ) result(self)
 
         implicit none
 
-        type(mpi_logger_type)                      :: self
+        type(mpi_logger_type)                  :: self
         integer,                    intent(in) :: level
         integer,                    intent(in) :: mpi_comm
+        integer,                    intent(in) :: mpi_rank
         character(len=*), optional, intent(in) :: id
         integer,          optional, intent(in) :: colour
         integer,          optional, intent(in) :: stop_level
@@ -136,16 +138,16 @@ contains
         character(len=32) :: result_string, fmt_tag_str
 
         if (trim(self%id) == "None") then
-            write( result_string, '(" ", A)' ) &
-                trim(get_log_level_str(level))
+            write( result_string, '("[P", I0, "] ", A)' ) &
+                self%mpi_rank, trim(get_log_level_str(level))
         else
             if (self%outputs_to_term) then
                 fmt_tag_str = change_colour(trim(self%id), self%colour_tag)
             else
                 fmt_tag_str = trim(self%id)
             end if
-            write( result_string, '("[", A,"] ", A)' ) &
-                trim(fmt_tag_str), trim(get_log_level_str(level))
+            write( result_string, '("[P", I0, "][", A,"] ", A)' ) &
+                 self%mpi_rank, trim(fmt_tag_str),trim(get_log_level_str(level))
         end if
 
     end function format_info

--- a/src/logger/mpi_logger_mod.F90
+++ b/src/logger/mpi_logger_mod.F90
@@ -3,7 +3,7 @@ module mpi_logger_mod
 #if defined(MPI)
 
     use, intrinsic :: iso_fortran_env, only : output_unit, error_unit
-    use mpi, only : mpi_abort, MPI_COMM_WORLD
+    use mpi, only : mpi_abort
 
     use abstract_logger_mod, only: abstract_logger_type
     use colour_mod,          only: change_colour, COLOUR_WHITE, COLOUR_GREY
@@ -21,6 +21,7 @@ module mpi_logger_mod
         integer           :: log_level
         integer           :: output_stream
         integer           :: colour_tag = COLOUR_WHITE
+        integer           :: mpi_comm
         integer           :: mpi_rank
         logical           :: outputs_to_term
         integer           :: stop_level = LEVEL_ERROR
@@ -58,7 +59,8 @@ contains
 
         self%output_stream = output_unit
         self%outputs_to_term = isatty(self%output_stream)
-        !self%mpi_comm = mpi_comm
+        self%mpi_comm = mpi_comm
+        self%mpi_rank = mpi_rank
 
         if (present(id)) self%id = trim(id)
         if (present(colour)) self%colour_tag = colour
@@ -153,8 +155,9 @@ contains
         implicit none
 
         class(mpi_logger_type), intent(inout) :: self
+        integer :: ierr
 
-        stop 1
+        call mpi_abort(self%mpi_comm, 1, ierr)
 
     end subroutine all_stop
 

--- a/src/logger/mpi_logger_mod.f90
+++ b/src/logger/mpi_logger_mod.f90
@@ -39,7 +39,7 @@ contains
 
         implicit none
 
-        type(logger_type)                      :: self
+        type(mpi_logger_type)                      :: self
         integer,                    intent(in) :: level
         integer,                    intent(in) :: mpi_comm
         character(len=*), optional, intent(in) :: id
@@ -56,7 +56,7 @@ contains
 
         self%output_stream = output_unit
         self%outputs_to_term = isatty(self%output_stream)
-        self%mpi_comm = mpi_comm
+        !self%mpi_comm = mpi_comm
 
         if (present(id)) self%id = trim(id)
         if (present(colour)) self%colour_tag = colour
@@ -72,7 +72,7 @@ contains
             end if
         end if
 
-    end function logger_constructor
+    end function mpi_logger_constructor
 
     !> Calls a logging event
     !!
@@ -82,7 +82,7 @@ contains
 
         implicit none
 
-        class(logger_type), intent(inout) :: self
+        class(mpi_logger_type), intent(inout) :: self
         character(len=*),   intent(in)    :: message
         integer,            intent(in)    :: level
 
@@ -126,7 +126,7 @@ contains
 
         implicit none
 
-        class(logger_type), intent(inout) :: self
+        class(mpi_logger_type), intent(inout) :: self
         integer,            intent(in)    :: level
 
         character(len=32) :: result_string, fmt_tag_str
@@ -150,7 +150,7 @@ contains
 
         implicit none
 
-        class(logger_type), intent(inout) :: self
+        class(mpi_logger_type), intent(inout) :: self
 
         stop 1
 

--- a/src/logger/mpi_logger_mod.f90
+++ b/src/logger/mpi_logger_mod.f90
@@ -1,5 +1,5 @@
 !> Module containing an flexible logger class
-module logger_mod
+module mpi_logger_mod
 
     use, intrinsic :: iso_fortran_env, only : output_unit, error_unit
 
@@ -14,11 +14,12 @@ module logger_mod
     private
 
     !> Logger class
-    type, public, extends(abstract_logger_type) :: logger_type
+    type, public, extends(abstract_logger_type) :: mpi_logger_type
         character(len=16) :: id = "None"
         integer           :: log_level
         integer           :: output_stream
         integer           :: colour_tag = COLOUR_WHITE
+        integer           :: mpi_rank
         logical           :: outputs_to_term
         integer           :: stop_level = LEVEL_ERROR
     contains
@@ -27,19 +28,20 @@ module logger_mod
         procedure         :: all_stop
     end type
 
-    interface logger_type
-        procedure :: logger_constructor
-    end interface logger_type
+    interface mpi_logger_type
+        procedure :: mpi_logger_constructor
+    end interface mpi_logger_type
 
 contains
 
     !> Constructor for the logger object
-    function logger_constructor(level, id, colour, stop_level) result(self)
+    function mpi_logger_constructor(level, id, colour, stop_level, mpi_comm) result(self)
 
         implicit none
 
         type(logger_type)                      :: self
         integer,                    intent(in) :: level
+        integer,                    intent(in) :: mpi_comm
         character(len=*), optional, intent(in) :: id
         integer,          optional, intent(in) :: colour
         integer,          optional, intent(in) :: stop_level
@@ -54,6 +56,7 @@ contains
 
         self%output_stream = output_unit
         self%outputs_to_term = isatty(self%output_stream)
+        self%mpi_comm = mpi_comm
 
         if (present(id)) self%id = trim(id)
         if (present(colour)) self%colour_tag = colour
@@ -153,4 +156,4 @@ contains
 
     end subroutine all_stop
 
-end module logger_mod
+end module mpi_logger_mod

--- a/src/oolong.f90
+++ b/src/oolong.f90
@@ -1,20 +1,23 @@
 module oolong
 
-  use abstract_logger_mod, only: abstract_logger_type
-  use logger_mod,          only: logger_type
-  use colour_mod,          only: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, &
-                                 COLOUR_BLUE, COLOUR_GREEN, COLOUR_YELLOW
-  use levels_mod,          only: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, &
-                                 LEVEL_INFO, LEVEL_DEBUG, LEVEL_TRACE
+    use abstract_logger_mod, only: abstract_logger_type
+    use logger_mod,          only: logger_type
+#if defined(MPI)
+    use mpi_logger_mod,      only: mpi_logger_type
+#endif
+    use colour_mod,          only: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, &
+                                    COLOUR_BLUE, COLOUR_GREEN, COLOUR_YELLOW
+    use levels_mod,          only: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, &
+                                    LEVEL_INFO, LEVEL_DEBUG, LEVEL_TRACE
 
-  implicit none
-  private
+    implicit none
+    private
 
-  public :: abstract_logger_type
-  public :: logger_type
-  public :: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, COLOUR_BLUE, &
-            COLOUR_GREEN, COLOUR_YELLOW
-  public :: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, LEVEL_INFO, &
-            LEVEL_DEBUG, LEVEL_TRACE
+    public :: abstract_logger_type
+    public :: logger_type
+    public :: COLOUR_WHITE, COLOUR_GREY, COLOUR_RED, COLOUR_BLUE, &
+              COLOUR_GREEN, COLOUR_YELLOW
+    public :: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, LEVEL_INFO, &
+              LEVEL_DEBUG, LEVEL_TRACE
 
 end module oolong

--- a/src/oolong.f90
+++ b/src/oolong.f90
@@ -19,5 +19,8 @@ module oolong
               COLOUR_GREEN, COLOUR_YELLOW
     public :: LEVEL_ALWAYS, LEVEL_ERROR, LEVEL_WARNING, LEVEL_INFO, &
               LEVEL_DEBUG, LEVEL_TRACE
+#if defined(MPI)
+    public :: mpi_logger_type
+#endif
 
 end module oolong

--- a/src/utils/datetime_mod.f90
+++ b/src/utils/datetime_mod.f90
@@ -1,0 +1,31 @@
+module datetime_mod
+
+    implicit none
+
+    private
+    public :: datetime_string
+
+contains
+
+    !> Gets formatted date/time information from iso_fortran_env
+    !!
+    !> return Character array of length 25
+    function datetime_string() result(result_string)
+
+        implicit none
+
+        character(len=25) :: result_string
+        integer :: datetime_values(8)
+
+        call date_and_time(values = datetime_values)
+
+        write( result_string,                                         &
+            '(I4,A1,I2.2,A1,I2.2,A1,I2.2,A1,I2.2,A1,I2.2,A1,I3.3)')  &
+                    datetime_values(1), "-", datetime_values(2), "-", &
+                    datetime_values(3), " ", datetime_values(5), ":", &
+                    datetime_values(6), ":", datetime_values(7), ".", &
+                    datetime_values(8)
+
+    end function datetime_string
+
+end module datetime_mod


### PR DESCRIPTION
This PR introduces an MPI logger class which fulfils the same level of functionality as its non-mpi counterpart along with some additional QoL features.

The Spack recipe now includes an MPI variant.